### PR TITLE
Updated Fragment_media_details

### DIFF
--- a/app/src/main/res/layout/fragment_media_details.xml
+++ b/app/src/main/res/layout/fragment_media_details.xml
@@ -149,7 +149,9 @@
                 android:id="@+id/recyclerCategoryList"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:paddingLeft="@dimen/dimen_8dp"
                 android:visibility="gone"
+                android:layout_marginLeft="@dimen/dimen_8dp"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/categoryLabel"
                 tools:listitem="@layout/item_rv_media_category" />
@@ -204,6 +206,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:visibility="gone"
+                android:paddingLeft="@dimen/dimen_8dp"
+                android:layout_marginLeft="@dimen/dimen_8dp"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/textViewFiles"
                 tools:listitem="@layout/item_rv_media_category" />
@@ -216,9 +220,7 @@
                 android:layout_marginTop="@dimen/margin_8dp"
                 android:background="@color/colorGrayLine"
                 app:layout_constraintTop_toBottomOf="@id/recyclerFileUsesList" />
-
-
-
+            
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/tv_author"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
Added Padding in category item and  file usage item

## What this PR does
This Pull request is in reference to issue #146 . Added Padding in category item and  file usage item of fragment_media_details. 

## Screenshots
**Before:**
![67163956-ebe5ee00-f392-11e9-845c-2ed99d1dcc06](https://user-images.githubusercontent.com/47180477/69697115-b0fc7600-1107-11ea-9b1c-6cd31ebd49d7.png)

**After:**

![Screenshot_2019-11-27-10-35-44-76_0670a9c18916db5d58d88e8d6ddc87a4](https://user-images.githubusercontent.com/47180477/69697182-ce314480-1107-11ea-928a-9f213a0adb47.png)

